### PR TITLE
use node js 20 runtime for docker actions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -102,9 +102,9 @@ runs:
     if: ${{ inputs.hadolint-enable == 'true' }}
     shell: bash
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v2
+    uses: docker/setup-buildx-action@v3
   - name: Build image
-    uses: docker/build-push-action@v4
+    uses: docker/build-push-action@v5
     with:
       context: ${{ inputs.path }}
       file: ${{ inputs.path }}/${{ inputs.dockerfile }}


### PR DESCRIPTION
## What's changed?

Update versions of `docker/setup-buildx-action` and `docker/build-push-action` that are using Node.js 16 as runtime.

## Why?
Node.js 16 became EOL on September 11th, 2023
https://nodejs.org/en/blog/announcements/nodejs16-eol

## References
https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
https://github.com/docker/build-push-action/releases/tag/v5.0.0