### PR TITLE
ci: bump renovate to v40.1.10

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run renovate
-        uses: renovatebot/github-action@v32.0.1
+        uses: renovatebot/github-action@v40.1.10
         with:
           token: ${{ secrets.MY_GITHUB_TOKEN }}
           configurationFile: renovate.json


### PR DESCRIPTION
## What's changed?
Bump [`renovatebot/github-action`](https://github.com/renovatebot/github-action) to `v40.1.10` .

## Why?
`renovatebot/github-action` uses Node.js 16 in `v39.2.4` or older.

## References
None
