### PR TITLE
ci: enable renovate github-actions manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
         ":disableDependencyDashboard"
     ],
     "enabledManagers": [
-        "regex"
+        "regex",
+        "github-actions"
     ],
     "labels": [
         "renovate"


### PR DESCRIPTION
## What's changed?
Enable renovate [github-actions manager](https://docs.renovatebot.com/modules/manager/github-actions/) .

## Why?
To create PR to update actions automatically.

## References
- https://docs.renovatebot.com/modules/manager/github-actions/