### PR TITLE
chore: add ecr public to trivy db and java-db repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ See [action.yaml](./action.yaml) .
     # Ignore unfixed vulnerabilities (default "false")
     trivy-ignore-unfixed: "false"
 
+    # OCI repository(ies) to retrieve trivy-db in order of priority
+    trivy-db-repository: "ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2"
+
+    # OCI repository(ies) to retrieve trivy-java-db in order of priority
+    trivy-java-db-repository: "ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1"
+
     # Enable scanning image by snyk (default "false")
     # If enabled, "snyk-token" must be also set.
     snyk-enable: "false"

--- a/action.yaml
+++ b/action.yaml
@@ -59,6 +59,14 @@ inputs:
     description: Ignore unfixed vulnerabilities (default "false")
     required: false
     default: "false"
+  trivy-db-repository:
+    description: OCI repository(ies) to retrieve trivy-db in order of priority
+    required: false
+    default: "ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2"
+  trivy-java-db-repository:
+    description: OCI repository(ies) to retrieve trivy-java-db in order of priority
+    required: false
+    default: "ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1"
   snyk-enable:
     description: Enable scanning image by snyk. If enabled, "snyk-token" must be also set. (default "false")
     required: false
@@ -152,6 +160,8 @@ runs:
       TRIVY_SEVERITY: "${{ inputs.trivy-severity }}"
       TRIVY_VULN_TYPE: "${{ inputs.trivy-vuln-type }}"
       IMAGE: "${{ inputs.tag }}"
+      TRIVY_DB_REPOSITORY: "${{ inputs.trivy-db-repository }}"
+      TRIVY_JAVA_DB_REPOSITORY: "${{ inputs.trivy-java-db-repository }}"
     if: ${{ inputs.trivy-enable == 'true' }}
     shell: bash
   - name: Scan image by snyk


### PR DESCRIPTION
## What's changed?

Add ECR public to trivy db and java-db repository.

If trivy fails to download artifacts from ghcr.io , trivy tries to download artifacts from ecr public.

## Why?

Fix #195 .

## References

- https://github.com/aquasecurity/trivy/discussions/7668
