### PR TITLE
chore: use `TRIVY_PKG_TYPES` instead of `TRIVY_VULN_TYPE`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -150,7 +150,7 @@ runs:
       TRIVY_IGNORE_UNFIXED: "${{ inputs.trivy-ignore-unfixed }}"
       TRIVY_NO_PROGRESS: "true"
       TRIVY_SEVERITY: "${{ inputs.trivy-severity }}"
-      TRIVY_VULN_TYPE: "${{ inputs.trivy-vuln-type }}"
+      TRIVY_PKG_TYPES: "${{ inputs.trivy-vuln-type }}"
       IMAGE: "${{ inputs.tag }}"
     if: ${{ inputs.trivy-enable == 'true' }}
     shell: bash


### PR DESCRIPTION
## What's changed?

Use `TRIVY_PKG_TYPES` instead of `TRIVY_VULN_TYPE` .

## Why?

`TRIVY_VULN_TYPE` is deprecated.

```
2024-11-06T01:03:21Z    WARN    'TRIVY_VULN_TYPE' is deprecated. Use 'TRIVY_PKG_TYPES' instead.
```

## References

None.
