### PR TITLE
revert!: Revert "chore: add ecr public to trivy db and java-db repository (#196)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ See [action.yaml](./action.yaml) .
     # Ignore unfixed vulnerabilities (default "false")
     trivy-ignore-unfixed: "false"
 
-    # OCI repository(ies) to retrieve trivy-db in order of priority
-    trivy-db-repository: "ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2"
-
-    # OCI repository(ies) to retrieve trivy-java-db in order of priority
-    trivy-java-db-repository: "ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1"
-
     # Enable scanning image by snyk (default "false")
     # If enabled, "snyk-token" must be also set.
     snyk-enable: "false"

--- a/action.yaml
+++ b/action.yaml
@@ -59,14 +59,6 @@ inputs:
     description: Ignore unfixed vulnerabilities (default "false")
     required: false
     default: "false"
-  trivy-db-repository:
-    description: OCI repository(ies) to retrieve trivy-db in order of priority
-    required: false
-    default: "ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2"
-  trivy-java-db-repository:
-    description: OCI repository(ies) to retrieve trivy-java-db in order of priority
-    required: false
-    default: "ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-db:1"
   snyk-enable:
     description: Enable scanning image by snyk. If enabled, "snyk-token" must be also set. (default "false")
     required: false
@@ -160,8 +152,6 @@ runs:
       TRIVY_SEVERITY: "${{ inputs.trivy-severity }}"
       TRIVY_PKG_TYPES: "${{ inputs.trivy-vuln-type }}"
       IMAGE: "${{ inputs.tag }}"
-      TRIVY_DB_REPOSITORY: "${{ inputs.trivy-db-repository }}"
-      TRIVY_JAVA_DB_REPOSITORY: "${{ inputs.trivy-java-db-repository }}"
     if: ${{ inputs.trivy-enable == 'true' }}
     shell: bash
   - name: Scan image by snyk


### PR DESCRIPTION
## What's changed?

Reverts #196

## Why?

Following options become unnecessary because trivy implemented registry fallbacks as default.

- `trivy-db-repository`
- `trivy-java-db-repository`

## References

- https://github.com/dentsusoken/build-and-scan-image/issues/195
- https://github.com/dentsusoken/build-and-scan-image/pull/196
