### PR TITLE
ci: split repository config and self-hosted config

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: renovatebot/github-action@85b17ebd5abf43d1c34c01bd4c8dbb8d45bbc2c7 # v43.0.7
         with:
           token: ${{ secrets.MY_GITHUB_TOKEN }}
-          configurationFile: renovate.json
+          configurationFile: renovate-config.json

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,5 @@
+{
+    "repositories": [
+        "dentsusoken/build-and-scan-image"
+    ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
-    "repositories": [
-        "dentsusoken/build-and-scan-image"
-    ],
     "extends": [
         "config:best-practices",
         ":prHourlyLimitNone",


### PR DESCRIPTION
## What's changed?

Split repository config and Self-Hosted config.

## Why?

[Self-hosted config options](https://docs.renovatebot.com/self-hosted-configuration/) should not be placed in the [repository config](https://docs.renovatebot.com/configuration-options/) file (e.g., `renovate.json`), because Renovate will ignore these config options and may also create a config error issue.

## References

- https://docs.renovatebot.com/configuration-options/
- https://docs.renovatebot.com/self-hosted-configuration/
